### PR TITLE
Fix dynamic-auth pairing: resolve real MAC address instead of a random one

### DIFF
--- a/custom_components/vidaa_tv/config_flow.py
+++ b/custom_components/vidaa_tv/config_flow.py
@@ -60,8 +60,26 @@ lib_path = Path(__file__).parent.parent.parent
 if str(lib_path) not in sys.path:
     sys.path.insert(0, str(lib_path))
 
-from pyvidaa import AsyncVidaaTV
+from pyvidaa import AsyncVidaaTV, delete_token
 from pyvidaa.discovery import probe_ip
+
+
+def _mac_from_model_description(model_desc: str) -> str | None:
+    """Extract the TV's real hardware MAC from an SSDP modelDescription blob.
+
+    Dynamic-auth credentials are derived from the MAC and the TV recomputes
+    the same hash using its own real MAC - a random MAC here will never
+    match, so the TV silently drops the session after the initial CONNACK.
+    """
+    for line in model_desc.split("\n"):
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if key in ("macWifi", "macEthernet", "mac") and value:
+            return value
+    return None
 
 
 def get_default_cert_paths(hass: HomeAssistant) -> tuple[str, str]:
@@ -93,8 +111,19 @@ async def validate_connection(
     brand: str = "his",
 ) -> dict[str, Any]:
     """Validate we can connect to the TV."""
-    # Use provided MAC or generate a random one for dynamic auth
-    mac = mac_address or generate_random_mac()
+    # Dynamic-auth credentials are derived from the MAC; the TV recomputes the
+    # same hash from its own real MAC, so a random one is never accepted past
+    # the initial CONNACK. Resolve the TV's real MAC via a UPnP probe before
+    # falling back to a random one (which will just fail).
+    mac = mac_address
+    if not mac:
+        try:
+            device = await hass.async_add_executor_job(probe_ip, host)
+            if device and device.mac:
+                mac = device.mac
+        except Exception as err:  # noqa: BLE001 - best effort, falls back below
+            _LOGGER.debug("Could not probe MAC for %s: %s", host, err)
+    mac = mac or generate_random_mac()
 
     tv = AsyncVidaaTV(
         host=host,
@@ -132,7 +161,7 @@ async def validate_connection(
                 tv_info.get("deviceid")
                 or device_info.get("wifi_mac")
                 or device_info.get("mac")
-                or self._host
+                or host
                 )
             result["sw_version"] = device_info.get("tv_version")
 
@@ -161,7 +190,8 @@ class VidaaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._port: int = DEFAULT_PORT
         self._name: str = DEFAULT_NAME
         self._device_id: str | None = None
-        self._mac: str = generate_random_mac()  # Random MAC for dynamic auth
+        self._mac: str = generate_random_mac()  # Placeholder until resolved
+        self._mac_resolved: bool = False  # True once _mac is a real hw MAC
         self._model: str | None = None
         self._brand: str | None = None
         self._sw_version: str | None = None
@@ -222,6 +252,7 @@ class VidaaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         self._port,
                         certfile=self._certfile,
                         keyfile=self._keyfile,
+                        mac_address=self._mac if self._mac_resolved else None,
                     )
                     self._name = info.get("name", DEFAULT_NAME)
                     self._device_id = info.get("device_id")
@@ -255,6 +286,7 @@ class VidaaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         self._port,
                         certfile=self._certfile,
                         keyfile=self._keyfile,
+                        mac_address=self._mac if self._mac_resolved else None,
                     )
                     self._name = info.get("name", DEFAULT_NAME)
                     self._device_id = info.get("device_id")
@@ -312,6 +344,13 @@ class VidaaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     # brand is an auth input (part of client_id/credentials)
                     self._brand = value
 
+        # The SSDP descriptor already carries the TV's real MAC - grab it so
+        # dynamic-auth credentials match what the TV itself will compute.
+        mac = _mac_from_model_description(model_desc)
+        if mac:
+            self._mac = mac
+            self._mac_resolved = True
+
         if not vidaa_support:
             _LOGGER.debug("SSDP device does not have vidaa_support=1, ignoring: %s",
                          discovery_info.ssdp_headers.get("_host"))
@@ -359,6 +398,7 @@ class VidaaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._port,
                 certfile=self._certfile,
                 keyfile=self._keyfile,
+                mac_address=self._mac if self._mac_resolved else None,
                 brand=self._brand or "his",
             )
             self._name = info.get("name", self._name)
@@ -399,7 +439,8 @@ class VidaaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._certfile = entry_data.get(CONF_CERTFILE)
         self._keyfile = entry_data.get(CONF_KEYFILE)
         self._device_id = entry_data.get(CONF_DEVICE_ID)
-        self._mac = generate_random_mac()  # New MAC for new auth
+        self._mac = generate_random_mac()  # Placeholder; resolved before pairing
+        self._mac_resolved = False
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
@@ -541,18 +582,44 @@ class VidaaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # this when there's no live pairing session - i.e. on first entry or
         # after a failed attempt that needs a fresh PIN.
         if self._pairing_tv is None:
-            # brand is an auth input. SSDP discovery already captured it from
-            # the descriptor; for the manual entry path, probe the TV's UPnP
-            # descriptor before connecting.
-            if not self._brand and self._host:
+            # brand and MAC are both auth inputs. SSDP discovery already
+            # captured them from the descriptor; for the manual entry path,
+            # probe the TV's UPnP descriptor before connecting. The MAC in
+            # particular matters: dynamic-auth credentials are a hash of it,
+            # and the TV recomputes that hash with its own real MAC, so a
+            # random placeholder is silently dropped right after CONNACK.
+            if (not self._brand or not self._mac_resolved) and self._host:
                 try:
                     device = await self.hass.async_add_executor_job(
                         probe_ip, self._host
                     )
                     if device and device.brand:
                         self._brand = device.brand
+                    if device and device.mac and not self._mac_resolved:
+                        self._mac = device.mac
+                        self._mac_resolved = True
                 except Exception as err:  # noqa: BLE001 - best effort, falls back to "his"
-                    _LOGGER.debug("Could not probe brand for %s: %s", self._host, err)
+                    _LOGGER.debug("Could not probe brand/MAC for %s: %s", self._host, err)
+
+            if not self._mac_resolved:
+                _LOGGER.warning(
+                    "Could not resolve %s's real MAC address; falling back to a "
+                    "random one for dynamic auth. The TV will likely reject this "
+                    "past the initial connect.",
+                    self._host,
+                )
+
+            # Clear any stale saved token for this host before pairing fresh -
+            # a leftover token (from an earlier interrupted attempt, or from
+            # before a TV firmware/pairing reset) makes the client try to
+            # reconnect/refresh with credentials the TV no longer honours
+            # instead of generating new ones, and start_pairing() never runs.
+            try:
+                await self.hass.async_add_executor_job(
+                    delete_token, None, self._host, self._port
+                )
+            except Exception as err:  # noqa: BLE001 - best effort
+                _LOGGER.debug("Could not clear stale token for %s: %s", self._host, err)
 
             tv = AsyncVidaaTV(
                 host=self._host,


### PR DESCRIPTION
## Problem

Pairing consistently fails with "TV is not responding. Make sure it
is powered on and connected to the network." (`tv_not_responding`),
even though the TV is reachable, the port is open, and the MQTT
transport connects fine ("Connected to TV" logs at INFO level from
pyvidaa.client). No PIN ever appears on the TV screen.

## Root cause

`VidaaTVConfigFlow` generates a random MAC address
(`generate_random_mac()`) for every pairing attempt and feeds it into
dynamic-auth credential generation. The TV computes the same
credentials independently from its *own real* MAC to validate the
session, so a random MAC can never produce matching credentials. The
TV accepts the transport-level MQTT CONNACK (which is why the
connection briefly looks successful in the logs), then drops the
session before `start_pairing()` gets far enough to put a PIN on
screen - the flow's connect() call returns False, and the generic
`tv_not_responding` abort fires with nothing else logged.

A stale saved token (e.g. from an earlier interrupted pairing attempt)
compounds this: `enable_persistence=True` means a leftover token
routes a fresh AsyncVidaaTV instance into `_load_saved_credentials()`'s
refresh path instead of generating new dynamic-auth credentials, so
even fixing the MAC alone isn't enough once a bad token is cached.

## Fix

- Extract the TV's real MAC from the SSDP `modelDescription`
  (`macWifi`/`macEthernet`) during discovery.
- For manual IP entry, reuse the existing `probe_ip()` UPnP probe
  (already used to resolve `brand`) to also read the real MAC.
- Only fall back to a random MAC if neither source resolves one.
- Clear any stale saved token for the host right before triggering a
  fresh pairing attempt.
- Also fixes a `NameError` (`self._host` referenced in a plain
  function, introduced in #4) in `validate_connection()`'s device_id
  fallback.

## Testing

Reproduced the bug and verified the fix end-to-end against a real
Hisense 58A53FEVS_0010 (VIDAA sw V0010.09.09A.P0930): pairing now
reliably reaches the PIN screen, and the resulting `media_player`/
`remote` entities work correctly (confirmed via a script that switches
the TV to the Disney+ activity).