### PR TITLE
Request pairing before checking needs_authentication()

### DIFF
--- a/custom_components/vidaa_tv/config_flow.py
+++ b/custom_components/vidaa_tv/config_flow.py
@@ -864,6 +864,22 @@ class VidaaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     # "auto" may have landed on a different scheme than the one
                     # we came in with; record it so the entry stores what works.
                     self._auth_mode = tv.auth_mode or self._auth_mode
+                    # needs_authentication() only reflects an auth-required push
+                    # the TV has actually sent - and that only happens in
+                    # response to vidaa_app_connect (or, for tokenless
+                    # firmware, an ordinary request start_pairing() also
+                    # sends), never proactively right after connect. Checking
+                    # it before requesting pairing read as "already
+                    # authorized" for every never-paired TV - including plain
+                    # MQTT ones, which still show a PIN on first pairing and
+                    # only skip re-authenticating on *later* connects. Always
+                    # request pairing first; the TV replies either way (PIN
+                    # shown, or a bare ack when genuinely already authorized),
+                    # and only THEN does needs_authentication() reflect
+                    # reality.
+                    started = await tv.async_start_pairing(
+                        wait_for_pin=TIMEOUT_PIN_DIALOG
+                    )
                     # A TV that needs no authentication (already authorized, or
                     # older firmware with a fixed static login) never shows a
                     # PIN and rejects any code entered - so asking for one would
@@ -896,16 +912,11 @@ class VidaaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         await tv.async_disconnect()
                         self._pairing_tv = None
                         return await self._create_entry_from_current_state()
-                    # Wait for the TV to confirm the dialog is actually on
-                    # screen rather than assuming it appeared - otherwise we
-                    # ask for a PIN the user cannot see.
-                    pin_shown = await tv.async_start_pairing(
-                        wait_for_pin=TIMEOUT_PIN_DIALOG
-                    )
                     # Hold the connection for the authenticate step either way:
                     # an already-authorized TV shows no PIN, and the entered
                     # code still has to go over this same session.
                     self._pairing_tv = tv
+                    pin_shown = started
                     if not pin_shown:
                         _LOGGER.warning(
                             "TV at %s did not confirm the PIN dialog; showing "

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -134,23 +134,32 @@ async def test_user_flow_no_auth_skips_pin(
     mock_certs_exist: MagicMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """A TV that needs no authentication is set up without a PIN prompt."""
-    # This TV never asks for a PIN (already authorized / static login).
+    """An already-authorized TV is set up without showing a PIN form.
+
+    needs_authentication() only reflects reality once pairing has actually
+    been requested - it reads False before that regardless of whether the TV
+    truly needs no auth or simply hasn't been asked yet, so the flow cannot
+    skip the request itself. It can still skip the PIN *form*: the TV acks
+    vidaa_app_connect without ever pushing the auth-required signal, exactly
+    what a genuinely already-authorized TV does.
+    """
     mock_config_flow_tv.needs_authentication = MagicMock(return_value=False)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    # Submitting the host should create the entry directly, skipping pairing.
+    # Submitting the host should create the entry directly, skipping the PIN form.
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_HOST: "192.168.1.100"},
     )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    # A PIN must never have been requested from the TV.
-    mock_config_flow_tv.async_start_pairing.assert_not_called()
+    # Pairing must still have been requested - it's the only way to learn
+    # whether the TV actually needs a PIN.
+    mock_config_flow_tv.async_start_pairing.assert_called_once()
+    # But since it never needed one, no PIN was ever submitted.
     mock_config_flow_tv.async_authenticate.assert_not_called()
 
 


### PR DESCRIPTION
Fixes #9.

## Problem

`needs_authentication()` only reflects an auth-required push the TV has
actually sent, and that only happens in response to `vidaa_app_connect`
(i.e. `start_pairing()`) - never proactively right after `connect()`.

#8 added a `needs_authentication()` check right after `connect()`, before
`start_pairing()` was ever called. So it always read `False` at that
point, for every TV, not just the plain-MQTT/already-authorized ones it
was meant for. Setup then silently created an unauthorized entry instead
of showing the PIN form - no PIN ever appeared on screen, and
`media_player`/`remote` were stuck unavailable afterward.

Confirmed directly against a real TV (dynamic auth, Hisense 85U86LAVT):
`needs_authentication()` was `False` right after `connect()`, and only
became `True` once `start_pairing()` was called.

## Fix

Move `start_pairing()` ahead of the `needs_authentication()` check, so
the check reflects what the TV actually reported instead of a default
that hasn't been updated yet.

The already-authorized case #8 was written for is unaffected: the TV
still acks the pairing request without ever raising the auth-required
flag, so `needs_authentication()` still reads `False` afterward and the
entry is created directly, skipping the PIN form - it just costs one
extra round trip (up to `TIMEOUT_PIN_DIALOG`) instead of skipping the
request outright, since there's no other way to tell "genuinely needs no
auth" apart from "hasn't been asked yet" with the current client API.

Also updates `test_user_flow_no_auth_skips_pin`, which asserted
`start_pairing` was never called in the no-auth case - that assertion
encoded the same premature-check bug.

## Testing

Verified end-to-end against a real TV: PIN now shows correctly on first
pairing, the entry authenticates, and `media_player`/`remote` report
live state instead of unavailable.

I wasn't able to run `tests/test_config_flow.py` locally -
`pytest-homeassistant-custom-component`'s latest release (0.13.205) pins
`homeassistant==2025.1.4`, which predates the API move of
`SsdpServiceInfo` to `homeassistant.helpers.service_info.ssdp` that
`config_flow.py` already imports, so the test module fails to collect.
Doesn't look related to this change - `validate.yml` doesn't run pytest
either, so this might already be a known gap. Happy to help sort out a
compatible pin in a separate PR if useful.
